### PR TITLE
Fix OpenLibrary API Usage & publication dates

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,15 +1,15 @@
-#
 name: Publish OCI
 
-# Configures this workflow to run every time a change is pushed to the branch called `release`.
+# Only publish if we tagged a new release
 on:
   push:
-    branches: ["main"]
+    tags: ["v*"]
 
-# Defines two custom environment variables for the workflow. These are used for the Container registry domain, and a name for the Docker image that this workflow builds.
+# Defines two custom environment variables for the workflow.
+# These are used for the Container registry domain, and a name for the Docker image that this workflow builds.
 env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
+  GH_REGISTRY: ghcr.io # Github Container Registry
+  FULL_IMAGE_NAME: ${{ github.repository }} # full image name: owner/image
 
 # There is a single job in this workflow. It's configured to run on the latest available version of Ubuntu.
 jobs:
@@ -25,41 +25,53 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+      # QEMU for software emulation of multiple platforms
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      # Docker buildx/buildkit for multi-platform builds
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       # Uses the `docker/login-action` action to log in to the Container registry registry
       # using the account and password that will publish the packages.
       # Once published, the packages are scoped to the account defined here.
       - name: Log in to the Container registry
         uses: docker/login-action@v3
         with:
-          registry: ${{ env.REGISTRY }}
+          registry: ${{ env.GH_REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       # This step uses [docker/metadata-action](https://github.com/docker/metadata-action#about)
       # to extract tags and labels that will be applied to the specified image.
       # The `id` "meta" allows the output of this step to be referenced in a subsequent step.
       # The `images` value provides the base name for the tags and labels.
-      - name: Extract metadata (tags, labels) for Docker
+      # tags and labels
+      - name: Extract metadata (tags, labels) for image ${{ env.FULL_IMAGE_NAME }}
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: ${{ env.GH_REGISTRY }}/${{ env.FULL_IMAGE_NAME }}
           tags: |
-            # set latest tag for default branch
+            type=semver,pattern={{version}}
             type=raw,value=latest,enable={{is_default_branch}}
-      # This step uses the `docker/build-push-action` action to build the image, based on your repository's `Dockerfile`.
-      # If the build succeeds, it pushes the image to GitHub Packages.
-      # It uses the `context` parameter to define the build's context as the set of files located in the specified path.
-      # For more information, see "[Usage](https://github.com/docker/build-push-action#usage)" in the README
-      # of the `docker/build-push-action` repository.
-      # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.
-      - name: Build and push Docker image
-        id: push
-        uses: docker/build-push-action@v6
+            type=ref,event=pr
+            type=ref,event=branch
+      - name: Get fresh build arguments
+        shell: bash
+        run: echo -e "BUILD_TIME=$(date -u '+%Y-%m-%d_%H:%M:%S')\nGITREF=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+        id: get_buildargs
+      - name: build and push docker image
+        uses: docker/build-push-action@v5
         with:
           context: .
           push: true
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            MY_VERSION=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}
+            MY_BUILTBY=github-action
+            BUILD_TIME=${{ steps.get_buildargs.outputs.BUILD_TIME }}
+            GITREF=${{ steps.get_buildargs.outputs.GITREF }}
 
       # This step generates an artifact attestation for the image,
       # which is an unforgeable statement about where and how it was built.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,6 +132,7 @@ When working with this codebase:
 ### Project Guidelines
 - Use `mix precommit` alias when you are done with all changes and fix any pending issues
 - Use the already included and available `:req` (`Req`) library for HTTP requests, **avoid** `:httpoison`, `:tesla`, and `:httpc`. Req is included by default and is the preferred HTTP client for Phoenix apps
+- Use `mix run -e` to run inline elixir code
 
 ### Elixir Guidelines
 - Elixir lists **do not support index based access via the access syntax** - use `Enum.at`, pattern matching, or `List` instead

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,13 @@ ARG DEBIAN_VERSION=bookworm-20250630-slim
 ARG BUILDER_IMAGE="docker.io/hexpm/elixir:${ELIXIR_VERSION}-erlang-${OTP_VERSION}-debian-${DEBIAN_VERSION}"
 ARG RUNNER_IMAGE="docker.io/debian:${DEBIAN_VERSION}"
 
+# standard Docker arguments
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+# custom build arguments
+ARG BUILD_TIME
+ARG GITREF
+
 FROM ${BUILDER_IMAGE} AS builder
 
 # install build dependencies
@@ -73,6 +80,9 @@ FROM ${RUNNER_IMAGE} AS final
 
 LABEL org.opencontainers.image.source=https://github.com/jfro/fuzzy_catalog
 LABEL org.opencontainers.image.licenses=MIT
+
+# persist these build time arguments into container as debug
+RUN echo "[$BUILD_TIME] [$GITREF] building on host that is $BUILDPLATFORM, for the target architecture $TARGETPLATFORM" > /build.log
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends libstdc++6 openssl libncurses5 locales ca-certificates \

--- a/lib/fuzzy_catalog/catalog/book_lookup.ex
+++ b/lib/fuzzy_catalog/catalog/book_lookup.ex
@@ -213,6 +213,7 @@ defmodule FuzzyCatalog.Catalog.BookLookup do
     |> normalize_pages()
     |> normalize_series_number()
     |> normalize_cover_url()
+    |> normalize_suggested_media_types()
   end
 
   defp normalize_pages(%{pages: 0} = book_data), do: %{book_data | pages: nil}
@@ -234,4 +235,14 @@ defmodule FuzzyCatalog.Catalog.BookLookup do
   end
 
   defp normalize_cover_url(book_data), do: book_data
+
+  defp normalize_suggested_media_types(%{suggested_media_types: nil} = book_data),
+    do: %{book_data | suggested_media_types: []}
+
+  defp normalize_suggested_media_types(%{suggested_media_types: types} = book_data)
+       when is_list(types),
+       do: book_data
+
+  defp normalize_suggested_media_types(book_data),
+    do: Map.put(book_data, :suggested_media_types, [])
 end

--- a/lib/fuzzy_catalog/catalog/providers/audiobookshelf_provider.ex
+++ b/lib/fuzzy_catalog/catalog/providers/audiobookshelf_provider.ex
@@ -258,19 +258,9 @@ defmodule FuzzyCatalog.Catalog.Providers.AudiobookshelfProvider do
       # Get cover URL - Audiobookshelf provides cover path
       cover_url = build_cover_url(item)
 
-      # Parse publication date
+      # Parse publication date using centralized DateUtils
       publication_date =
-        case metadata["publishedYear"] do
-          year when is_integer(year) and year > 0 ->
-            Date.new(year, 1, 1)
-            |> case do
-              {:ok, date} -> date
-              _ -> nil
-            end
-
-          _ ->
-            nil
-        end
+        FuzzyCatalog.DateUtils.parse_audiobookshelf_year(metadata["publishedYear"])
 
       # Parse series number
       series_number =

--- a/lib/fuzzy_catalog/catalog/providers/calibre_provider.ex
+++ b/lib/fuzzy_catalog/catalog/providers/calibre_provider.ex
@@ -231,7 +231,7 @@ defmodule FuzzyCatalog.Catalog.Providers.CalibreProvider do
       ] = row
 
       # Parse publication date
-      publication_date = parse_publication_date(pubdate)
+      publication_date = FuzzyCatalog.DateUtils.parse_calibre_date(pubdate)
 
       # Get additional identifiers
       {isbn10, isbn13, asin} = get_book_identifiers(db, book_id, isbn)
@@ -267,19 +267,6 @@ defmodule FuzzyCatalog.Catalog.Providers.CalibreProvider do
         nil
     end
   end
-
-  defp parse_publication_date(nil), do: nil
-  defp parse_publication_date(""), do: nil
-
-  defp parse_publication_date(pubdate) when is_binary(pubdate) do
-    # Calibre stores dates as ISO strings, sometimes with timezone
-    case Date.from_iso8601(String.slice(pubdate, 0, 10)) do
-      {:ok, date} -> date
-      {:error, _} -> nil
-    end
-  end
-
-  defp parse_publication_date(_), do: nil
 
   defp get_book_identifiers(db, book_id, main_isbn) do
     # Query identifiers table for additional ISBNs and ASINs

--- a/lib/fuzzy_catalog/catalog/providers/google_books_provider.ex
+++ b/lib/fuzzy_catalog/catalog/providers/google_books_provider.ex
@@ -134,7 +134,7 @@ defmodule FuzzyCatalog.Catalog.Providers.GoogleBooksProvider do
       isbn10: isbn10,
       isbn13: isbn13,
       publisher: volume_info["publisher"],
-      publication_date: parse_google_date(volume_info["publishedDate"]),
+      publication_date: FuzzyCatalog.DateUtils.parse_date(volume_info["publishedDate"]),
       pages: volume_info["pageCount"],
       genre: List.first(volume_info["categories"] || []),
       description: volume_info["description"],
@@ -166,20 +166,4 @@ defmodule FuzzyCatalog.Catalog.Providers.GoogleBooksProvider do
   end
 
   defp extract_google_series(_), do: nil
-
-  defp parse_google_date(nil), do: nil
-
-  defp parse_google_date(date_string) when is_binary(date_string) do
-    case Date.from_iso8601(date_string) do
-      {:ok, date} ->
-        date
-
-      {:error, _} ->
-        # Try to parse just the year
-        case Regex.run(~r/\d{4}/, date_string) do
-          [year] -> Date.new!(String.to_integer(year), 1, 1)
-          _ -> nil
-        end
-    end
-  end
 end

--- a/lib/fuzzy_catalog/catalog/providers/google_books_provider.ex
+++ b/lib/fuzzy_catalog/catalog/providers/google_books_provider.ex
@@ -139,7 +139,8 @@ defmodule FuzzyCatalog.Catalog.Providers.GoogleBooksProvider do
       genre: List.first(volume_info["categories"] || []),
       description: volume_info["description"],
       series: extract_google_series(volume_info["seriesInfo"]),
-      cover_url: get_in(volume_info, ["imageLinks", "thumbnail"])
+      cover_url: get_in(volume_info, ["imageLinks", "thumbnail"]),
+      suggested_media_types: []
     }
   end
 

--- a/lib/fuzzy_catalog/catalog/providers/library_of_congress_provider.ex
+++ b/lib/fuzzy_catalog/catalog/providers/library_of_congress_provider.ex
@@ -233,7 +233,7 @@ defmodule FuzzyCatalog.Catalog.Providers.LibraryOfCongressProvider do
     case date_nodes do
       [date_node | _] ->
         date_string = extract_text_from_node(date_node)
-        parse_date(date_string)
+        FuzzyCatalog.DateUtils.parse_date(date_string)
 
       [] ->
         nil
@@ -294,20 +294,6 @@ defmodule FuzzyCatalog.Catalog.Providers.LibraryOfCongressProvider do
 
       [] ->
         nil
-    end
-  end
-
-  defp parse_date(date_string) when is_binary(date_string) do
-    case Date.from_iso8601(date_string) do
-      {:ok, date} ->
-        date
-
-      {:error, _} ->
-        # Try to parse just the year
-        case Regex.run(~r/\d{4}/, date_string) do
-          [year] -> Date.new!(String.to_integer(year), 1, 1)
-          _ -> nil
-        end
     end
   end
 

--- a/lib/fuzzy_catalog/catalog/providers/library_of_congress_provider.ex
+++ b/lib/fuzzy_catalog/catalog/providers/library_of_congress_provider.ex
@@ -148,7 +148,8 @@ defmodule FuzzyCatalog.Catalog.Providers.LibraryOfCongressProvider do
       subtitle: extract_subtitle(mods_element),
       description: extract_description(mods_element),
       genre: extract_genre(mods_element),
-      series: extract_series(mods_element)
+      series: extract_series(mods_element),
+      suggested_media_types: []
     }
   end
 

--- a/lib/fuzzy_catalog/catalog/providers/open_library_provider.ex
+++ b/lib/fuzzy_catalog/catalog/providers/open_library_provider.ex
@@ -9,7 +9,6 @@ defmodule FuzzyCatalog.Catalog.Providers.OpenLibraryProvider do
   alias FuzzyCatalog.Catalog.BookLookupProvider
 
   @base_url "https://openlibrary.org"
-  @books_api_url "#{@base_url}/api/books"
   @search_api_url "#{@base_url}/search.json"
   @covers_api_url "https://covers.openlibrary.org"
 
@@ -19,12 +18,12 @@ defmodule FuzzyCatalog.Catalog.Providers.OpenLibraryProvider do
 
     case validate_isbn(clean_isbn) do
       :valid ->
-        bibkey = "ISBN:#{clean_isbn}"
-        url = "#{@books_api_url}?bibkeys=#{bibkey}&format=json&jscmd=data"
+        url =
+          "#{@search_api_url}?isbn=#{clean_isbn}&fields=title,author_name,first_publish_year,publish_date,isbn,publisher,key,subtitle,subject,format,editions&limit=1"
 
         case make_request(url) do
           {:ok, response} ->
-            parse_book_response(response, bibkey)
+            parse_isbn_search_response(response)
 
           {:error, reason} ->
             {:error, reason}
@@ -45,7 +44,7 @@ defmodule FuzzyCatalog.Catalog.Providers.OpenLibraryProvider do
         encoded_title = URI.encode(clean_title)
 
         url =
-          "#{@search_api_url}?title=#{encoded_title}&fields=title,author_name,first_publish_year,publish_date,isbn,publisher,key,subtitle,subject&limit=10"
+          "#{@search_api_url}?title=#{encoded_title}&fields=title,author_name,first_publish_year,publish_date,isbn,publisher,key,subtitle,subject,format&limit=10"
 
         case make_request(url) do
           {:ok, response} ->
@@ -63,7 +62,7 @@ defmodule FuzzyCatalog.Catalog.Providers.OpenLibraryProvider do
 
     if String.length(clean_upc) == 12 do
       url =
-        "#{@search_api_url}?q=#{clean_upc}&fields=title,author_name,first_publish_year,publish_date,isbn,publisher,key,subtitle,subject&limit=5"
+        "#{@search_api_url}?q=#{clean_upc}&fields=title,author_name,first_publish_year,publish_date,isbn,publisher,key,subtitle,subject,format&limit=5"
 
       case make_request(url) do
         {:ok, response} ->
@@ -81,6 +80,61 @@ defmodule FuzzyCatalog.Catalog.Providers.OpenLibraryProvider do
   def provider_name, do: "OpenLibrary"
 
   # Private functions
+
+  defp map_format_to_media_type(format) when is_binary(format) do
+    format_lower = String.downcase(String.trim(format))
+
+    cond do
+      String.contains?(format_lower, "hardcover") or String.contains?(format_lower, "hardback") ->
+        "hardcover"
+
+      String.contains?(format_lower, "paperback") or String.contains?(format_lower, "softcover") ->
+        "paperback"
+
+      String.contains?(format_lower, "audiobook") or String.contains?(format_lower, "audio") or
+        String.contains?(format_lower, "mp3") or String.contains?(format_lower, "cd") ->
+        "audiobook"
+
+      String.contains?(format_lower, "ebook") or String.contains?(format_lower, "e-book") or
+        String.contains?(format_lower, "digital") or String.contains?(format_lower, "epub") or
+          String.contains?(format_lower, "kindle") ->
+        "ebook"
+
+      true ->
+        nil
+    end
+  end
+
+  defp map_format_to_media_type(_), do: nil
+
+  defp extract_media_types_from_formats(nil), do: []
+  defp extract_media_types_from_formats([]), do: []
+
+  defp extract_media_types_from_formats(formats) when is_list(formats) do
+    formats
+    |> Enum.map(&map_format_to_media_type/1)
+    |> Enum.filter(& &1)
+    |> Enum.uniq()
+  end
+
+  defp extract_formats_from_editions(nil), do: []
+  defp extract_formats_from_editions(%{"docs" => []}), do: []
+
+  defp extract_formats_from_editions(%{"docs" => editions}) when is_list(editions) do
+    editions
+    |> Enum.flat_map(fn edition ->
+      case edition["format"] do
+        format when is_binary(format) -> [format]
+        formats when is_list(formats) -> formats
+        _ -> []
+      end
+    end)
+    |> Enum.map(&map_format_to_media_type/1)
+    |> Enum.filter(& &1)
+    |> Enum.uniq()
+  end
+
+  defp extract_formats_from_editions(_), do: []
 
   defp make_request(url) do
     Logger.info("OpenLibrary: Making request to: #{url}")
@@ -111,16 +165,6 @@ defmodule FuzzyCatalog.Catalog.Providers.OpenLibraryProvider do
     end
   end
 
-  defp parse_book_response(response, bibkey) do
-    case response do
-      %{^bibkey => book_data} ->
-        {:ok, normalize_book_data(book_data)}
-
-      _ ->
-        {:error, "Book not found"}
-    end
-  end
-
   defp parse_search_response(%{"docs" => docs, "num_found" => num_found}) when num_found > 0 do
     books = Enum.map(docs, &normalize_search_result/1)
     {:ok, books}
@@ -134,25 +178,18 @@ defmodule FuzzyCatalog.Catalog.Providers.OpenLibraryProvider do
     {:error, "Invalid response format"}
   end
 
-  defp normalize_book_data(data) do
-    isbn10 = extract_isbn(data, 10)
-    isbn13 = extract_isbn(data, 13)
+  defp parse_isbn_search_response(%{"docs" => [doc | _], "num_found" => num_found})
+       when num_found > 0 do
+    book_data = normalize_isbn_search_result(doc)
+    {:ok, book_data}
+  end
 
-    %{
-      title: get_in(data, ["title"]) || "Unknown Title",
-      author: extract_authors(get_in(data, ["authors"])),
-      isbn10: isbn10,
-      isbn13: isbn13,
-      publisher: extract_first_publisher(get_in(data, ["publishers"])),
-      publication_date: extract_publish_date(get_in(data, ["publish_date"])),
-      pages: get_in(data, ["number_of_pages"]),
-      cover_url: generate_cover_url(isbn13 || isbn10),
-      # New fields
-      subtitle: get_in(data, ["subtitle"]),
-      description: extract_description(data),
-      genre: extract_subjects(get_in(data, ["subjects"])),
-      series: extract_series(data)
-    }
+  defp parse_isbn_search_response(%{"num_found" => 0}) do
+    {:error, "Book not found"}
+  end
+
+  defp parse_isbn_search_response(_) do
+    {:error, "Invalid response format"}
   end
 
   defp normalize_search_result(doc) do
@@ -170,7 +207,31 @@ defmodule FuzzyCatalog.Catalog.Providers.OpenLibraryProvider do
       cover_url: generate_cover_url(isbn13 || isbn10),
       # New fields from search results
       subtitle: doc["subtitle"],
-      genre: extract_search_subjects(doc["subject"])
+      genre: extract_search_subjects(doc["subject"]),
+      suggested_media_types: extract_media_types_from_formats(doc["format"])
+    }
+  end
+
+  defp normalize_isbn_search_result(doc) do
+    isbn10 = extract_isbn_from_list(doc["isbn"], 10)
+    isbn13 = extract_isbn_from_list(doc["isbn"], 13)
+
+    # Extract format from editions if available
+    edition_formats = extract_formats_from_editions(doc["editions"])
+
+    %{
+      title: doc["title"] || "Unknown Title",
+      author: extract_author_names(doc["author_name"]),
+      isbn10: isbn10,
+      isbn13: isbn13,
+      publisher: List.first(doc["publisher"] || []),
+      publication_date: extract_search_publish_date(doc),
+      key: doc["key"],
+      cover_url: generate_cover_url(isbn13 || isbn10),
+      # New fields from search results
+      subtitle: doc["subtitle"],
+      genre: extract_search_subjects(doc["subject"]),
+      suggested_media_types: edition_formats
     }
   end
 
@@ -182,27 +243,11 @@ defmodule FuzzyCatalog.Catalog.Providers.OpenLibraryProvider do
     "#{@covers_api_url}/b/isbn/#{clean_isbn}-M.jpg"
   end
 
-  defp extract_authors(nil), do: "Unknown Author"
-  defp extract_authors([]), do: "Unknown Author"
-
-  defp extract_authors(authors) when is_list(authors) do
-    authors
-    |> Enum.map(fn author -> author["name"] || "Unknown" end)
-    |> Enum.join(", ")
-  end
-
   defp extract_author_names(nil), do: "Unknown Author"
   defp extract_author_names([]), do: "Unknown Author"
 
   defp extract_author_names(names) when is_list(names) do
     Enum.join(names, ", ")
-  end
-
-  defp extract_isbn(data, length) do
-    case get_in(data, ["identifiers", "isbn_#{length}"]) do
-      [isbn | _] -> isbn
-      _ -> nil
-    end
   end
 
   defp extract_isbn_from_list(nil, _length), do: nil
@@ -212,17 +257,6 @@ defmodule FuzzyCatalog.Catalog.Providers.OpenLibraryProvider do
     Enum.find(isbns, fn isbn ->
       String.length(String.replace(isbn, ~r/[^0-9X]/, "")) == length
     end)
-  end
-
-  defp extract_first_publisher(nil), do: nil
-  defp extract_first_publisher([]), do: nil
-
-  defp extract_first_publisher([publisher | _]) when is_map(publisher) do
-    publisher["name"]
-  end
-
-  defp extract_first_publisher([publisher | _]) when is_binary(publisher) do
-    publisher
   end
 
   defp extract_publish_date(nil), do: nil
@@ -258,33 +292,6 @@ defmodule FuzzyCatalog.Catalog.Providers.OpenLibraryProvider do
     end
   end
 
-  defp extract_description(data) do
-    case get_in(data, ["description"]) do
-      %{"value" => value} when is_binary(value) -> value
-      value when is_binary(value) -> value
-      _ -> nil
-    end
-  end
-
-  defp extract_subjects(nil), do: nil
-  defp extract_subjects([]), do: nil
-
-  defp extract_subjects(subjects) when is_list(subjects) do
-    subjects
-    # Limit to first 3 subjects
-    |> Enum.take(3)
-    |> Enum.map(fn
-      %{"name" => name} when is_binary(name) -> name
-      subject when is_binary(subject) -> subject
-      _ -> nil
-    end)
-    |> Enum.filter(& &1)
-    |> case do
-      [] -> nil
-      names -> Enum.join(names, ", ")
-    end
-  end
-
   defp extract_search_subjects(nil), do: nil
   defp extract_search_subjects([]), do: nil
 
@@ -293,14 +300,5 @@ defmodule FuzzyCatalog.Catalog.Providers.OpenLibraryProvider do
     # Limit to first 3 subjects
     |> Enum.take(3)
     |> Enum.join(", ")
-  end
-
-  defp extract_series(data) do
-    # OpenLibrary might have series info in different places
-    case get_in(data, ["series"]) do
-      [series | _] when is_binary(series) -> series
-      series when is_binary(series) -> series
-      _ -> nil
-    end
   end
 end

--- a/lib/fuzzy_catalog/catalog/providers/open_library_provider.ex
+++ b/lib/fuzzy_catalog/catalog/providers/open_library_provider.ex
@@ -259,20 +259,8 @@ defmodule FuzzyCatalog.Catalog.Providers.OpenLibraryProvider do
     end)
   end
 
-  defp extract_publish_date(nil), do: nil
-
-  defp extract_publish_date(date) when is_binary(date) do
-    case Date.from_iso8601(date) do
-      {:ok, parsed_date} ->
-        parsed_date
-
-      {:error, _} ->
-        # Try to parse just the year if full date parsing fails
-        case Regex.run(~r/\d{4}/, date) do
-          [year] -> Date.new!(String.to_integer(year), 1, 1)
-          _ -> nil
-        end
-    end
+  defp extract_publish_date(date) do
+    FuzzyCatalog.DateUtils.parse_date(date)
   end
 
   defp extract_search_publish_date(doc) do
@@ -286,7 +274,7 @@ defmodule FuzzyCatalog.Catalog.Providers.OpenLibraryProvider do
 
       _ ->
         case doc["first_publish_year"] do
-          year when is_integer(year) -> Date.new!(year, 1, 1)
+          year when is_integer(year) -> FuzzyCatalog.DateUtils.parse_date(year)
           _ -> nil
         end
     end

--- a/lib/fuzzy_catalog/date_utils.ex
+++ b/lib/fuzzy_catalog/date_utils.ex
@@ -1,0 +1,226 @@
+defmodule FuzzyCatalog.DateUtils do
+  @moduledoc """
+  Centralized utilities for parsing and handling dates in various formats,
+  particularly for converting them to ISO 8601 partial date strings.
+
+  This module handles date parsing from multiple sources including:
+  - External book providers (Google Books, Open Library, etc.)
+  - User input in forms
+  - Various date string formats
+
+  All functions return ISO 8601 partial date strings like:
+  - "2023" (year only)
+  - "2023-05" (year-month)
+  - "2023-05-15" (full date)
+  """
+
+  @doc """
+  Parse a date string from any source into an ISO 8601 partial date string.
+
+  This is the main entry point for date parsing and handles:
+  - Full ISO dates: "2023-05-15" -> "2023-05-15"
+  - Year only: "2023" -> "2023"
+  - Year from regex extraction: "Published in 2023" -> "2023"
+  - Slash separated: "2023/05/15" -> "2023-05-15"
+  - Integer years: 2023 -> "2023"
+
+  ## Examples
+
+      iex> FuzzyCatalog.DateUtils.parse_date("2023-05-15")
+      "2023-05-15"
+      
+      iex> FuzzyCatalog.DateUtils.parse_date("2023")
+      "2023"
+      
+      iex> FuzzyCatalog.DateUtils.parse_date("Published in 2023")
+      "2023"
+      
+      iex> FuzzyCatalog.DateUtils.parse_date(nil)
+      nil
+  """
+  def parse_date(nil), do: nil
+  def parse_date(""), do: nil
+
+  def parse_date(year) when is_integer(year) do
+    current_year = Date.utc_today().year
+
+    if year >= 1000 and year <= current_year + 10 do
+      String.pad_leading(to_string(year), 4, "0")
+    else
+      nil
+    end
+  end
+
+  def parse_date(date_string) when is_binary(date_string) do
+    trimmed = String.trim(date_string)
+
+    cond do
+      # Try parsing as full ISO 8601 date first
+      match?({:ok, _}, Date.from_iso8601(trimmed)) ->
+        case Date.from_iso8601(trimmed) do
+          {:ok, %Date{year: year, month: month, day: day}} ->
+            current_year = Date.utc_today().year
+
+            if year >= 1000 and year <= current_year + 10 do
+              # Return full ISO date string
+              year_str = String.pad_leading(to_string(year), 4, "0")
+              month_str = String.pad_leading(to_string(month), 2, "0")
+              day_str = String.pad_leading(to_string(day), 2, "0")
+              "#{year_str}-#{month_str}-#{day_str}"
+            else
+              nil
+            end
+        end
+
+      # Check if it's already a partial ISO date (YYYY or YYYY-MM)
+      Regex.match?(~r/^\d{4}(-\d{2})?$/, trimmed) ->
+        case validate_partial_iso_date(trimmed) do
+          {:ok, validated_date} -> validated_date
+          :error -> parse_date_fallback(trimmed)
+        end
+
+      # Try parsing as slash-separated date (YYYY/MM/DD, YYYY/MM)
+      Regex.match?(~r/^\d{4}(\/\d{1,2}(\/\d{1,2})?)?$/, trimmed) ->
+        convert_slash_date_to_iso(trimmed)
+
+      # Extract year from text (e.g., "Published in 2023", "2023 edition")
+      true ->
+        parse_year_from_text(trimmed)
+    end
+  end
+
+  def parse_date(_), do: nil
+
+  @doc """
+  Parse flexible date input, particularly useful for user form input.
+  This handles a wide variety of input formats and is more lenient.
+  """
+  def parse_flexible_date_input(input) do
+    parse_date(input)
+  end
+
+  @doc """
+  Parse publication dates specifically from Calibre database.
+  Calibre stores dates as ISO strings, sometimes with timezone info.
+  """
+  def parse_calibre_date(nil), do: nil
+  def parse_calibre_date(""), do: nil
+
+  def parse_calibre_date(pubdate) when is_binary(pubdate) do
+    # Calibre stores dates as ISO strings, sometimes with timezone
+    # Extract just the date part (first 10 characters)
+    iso_date_part = String.slice(pubdate, 0, 10)
+    parse_date(iso_date_part)
+  end
+
+  def parse_calibre_date(_), do: nil
+
+  @doc """
+  Parse year values from Audiobookshelf metadata.
+  Handles both integer and string year values with appropriate logging.
+  """
+  def parse_audiobookshelf_year(nil), do: nil
+
+  def parse_audiobookshelf_year(year) when is_integer(year) and year > 0 do
+    parse_date(year)
+  end
+
+  def parse_audiobookshelf_year(year_str) when is_binary(year_str) do
+    case String.trim(year_str) |> Integer.parse() do
+      {year, _} when year > 0 ->
+        current_year = Date.utc_today().year
+
+        if year <= current_year + 10 do
+          parse_date(year)
+        else
+          require Logger
+          Logger.warning("publishedYear too far in future in Audiobookshelf: #{year}")
+          nil
+        end
+
+      _ ->
+        require Logger
+        Logger.warning("Invalid publishedYear format in Audiobookshelf: #{inspect(year_str)}")
+        nil
+    end
+  end
+
+  def parse_audiobookshelf_year(other) do
+    require Logger
+    Logger.debug("No valid publishedYear found in Audiobookshelf metadata: #{inspect(other)}")
+    nil
+  end
+
+  # Private helper functions
+
+  defp validate_partial_iso_date(date_string) do
+    current_year = Date.utc_today().year
+
+    case String.split(date_string, "-") do
+      # Year only: "2023"
+      [year_str] when byte_size(year_str) == 4 ->
+        case Integer.parse(year_str) do
+          {year, ""} when year >= 1000 and year <= current_year + 10 ->
+            {:ok, date_string}
+
+          _ ->
+            :error
+        end
+
+      # Year-month: "2023-05"
+      [year_str, month_str] when byte_size(year_str) == 4 and byte_size(month_str) == 2 ->
+        with {year, ""} <- Integer.parse(year_str),
+             {month, ""} <- Integer.parse(month_str),
+             true <- year >= 1000 and year <= current_year + 10,
+             true <- month >= 1 and month <= 12 do
+          {:ok, date_string}
+        else
+          _ -> :error
+        end
+
+      _ ->
+        :error
+    end
+  end
+
+  defp convert_slash_date_to_iso(date_string) do
+    date_string
+    |> String.replace("/", "-")
+    |> ensure_two_digit_components()
+    |> parse_date()
+  end
+
+  defp ensure_two_digit_components(date_string) do
+    case String.split(date_string, "-") do
+      [year] ->
+        year
+
+      [year, month] ->
+        "#{year}-#{String.pad_leading(month, 2, "0")}"
+
+      [year, month, day] ->
+        "#{year}-#{String.pad_leading(month, 2, "0")}-#{String.pad_leading(day, 2, "0")}"
+
+      _ ->
+        date_string
+    end
+  end
+
+  defp parse_year_from_text(text) do
+    case Regex.run(~r/\b(\d{4})\b/, text) do
+      [_, year] ->
+        case Integer.parse(year) do
+          {year_int, _} -> parse_date(year_int)
+          _ -> nil
+        end
+
+      _ ->
+        nil
+    end
+  end
+
+  defp parse_date_fallback(date_string) do
+    # Last resort: try to extract year from the string
+    parse_year_from_text(date_string)
+  end
+end

--- a/lib/fuzzy_catalog_web/controllers/book_html.ex
+++ b/lib/fuzzy_catalog_web/controllers/book_html.ex
@@ -82,4 +82,149 @@ defmodule FuzzyCatalogWeb.BookHTML do
   """
   def view_toggle_label("grid"), do: "List View"
   def view_toggle_label(_), do: "Grid View"
+
+  @doc """
+  Returns the current sort field and direction from Flop metadata.
+  """
+  def current_sort(%Flop.Meta{
+        flop: %Flop{order_by: order_by, order_directions: order_directions}
+      })
+      when is_list(order_by) and is_list(order_directions) do
+    case {order_by, order_directions} do
+      {[field], [direction]} when is_atom(field) and is_atom(direction) ->
+        {field, direction}
+
+      {[field], [direction]} when is_binary(field) and is_binary(direction) ->
+        {String.to_existing_atom(field), String.to_existing_atom(direction)}
+
+      # default
+      _ ->
+        {:title, :asc}
+    end
+  rescue
+    # fallback if atom conversion fails
+    ArgumentError -> {:title, :asc}
+  end
+
+  def current_sort(_), do: {:title, :asc}
+
+  @doc """
+  Returns available sort options as a list of {label, field, direction} tuples.
+  """
+  def sort_options do
+    [
+      {"Recently Added", :inserted_at, :desc},
+      {"Title A-Z", :title, :asc},
+      {"Title Z-A", :title, :desc},
+      {"Author A-Z", :author, :asc},
+      {"Author Z-A", :author, :desc},
+      {"Publication Date (Newest)", :publication_date, :desc},
+      {"Publication Date (Oldest)", :publication_date, :asc}
+    ]
+  end
+
+  @doc """
+  Returns the label for the current sort option.
+  """
+  def current_sort_label(meta) do
+    {field, direction} = current_sort(meta)
+
+    case {field, direction} do
+      {:inserted_at, :desc} -> "Recently Added"
+      {:title, :asc} -> "Title A-Z"
+      {:title, :desc} -> "Title Z-A"
+      {:author, :asc} -> "Author A-Z"
+      {:author, :desc} -> "Author Z-A"
+      {:publication_date, :desc} -> "Publication Date (Newest)"
+      {:publication_date, :asc} -> "Publication Date (Oldest)"
+      # fallback
+      _ -> "Title A-Z"
+    end
+  end
+
+  @doc """
+  Builds a URL with the specified sort parameters while preserving search and view parameters.
+  """
+  def build_sort_url(conn, _meta, field, direction) do
+    # Extract current parameters
+    search_value =
+      case conn.query_params do
+        %{"filters" => %{"search" => search}} when is_binary(search) and search != "" -> search
+        _ -> nil
+      end
+
+    view_mode = conn.query_params["view"] || "list"
+
+    # Build query parameters with sort - Flop expects arrays for order_by and order_directions
+    query_params = %{
+      "order_by[]" => to_string(field),
+      "order_directions[]" => to_string(direction),
+      "view" => view_mode
+    }
+
+    query_params =
+      if search_value do
+        Map.put(query_params, "filters[search]", search_value)
+      else
+        query_params
+      end
+
+    encoded_params = URI.encode_query(query_params)
+
+    case encoded_params do
+      "" -> conn.request_path
+      params -> "#{conn.request_path}?#{params}"
+    end
+  end
+
+  @doc """
+  Builds the pagination path preserving current view mode and search parameters.
+  """
+  def pagination_path(conn) do
+    view_mode = conn.query_params["view"]
+
+    search_value =
+      case conn.query_params do
+        %{"filters" => %{"search" => search}} when is_binary(search) and search != "" -> search
+        _ -> nil
+      end
+
+    query_params = %{}
+
+    query_params =
+      if view_mode do
+        Map.put(query_params, "view", view_mode)
+      else
+        query_params
+      end
+
+    query_params =
+      if search_value do
+        Map.put(query_params, "filters[search]", search_value)
+      else
+        query_params
+      end
+
+    case URI.encode_query(query_params) do
+      "" -> ~p"/books"
+      params -> "/books?#{params}"
+    end
+  end
+
+  @doc """
+  Parses flexible date input into ISO 8601 partial date string.
+  Delegates to the centralized DateUtils module.
+  """
+  def parse_flexible_date_input(input) do
+    FuzzyCatalog.DateUtils.parse_flexible_date_input(input)
+  end
+
+  @doc """
+  Formats an ISO 8601 partial date string for display.
+  Since we're storing ISO strings directly, this is mostly a pass-through.
+  """
+  def format_publication_date(nil), do: ""
+  def format_publication_date(""), do: ""
+  def format_publication_date(iso_string) when is_binary(iso_string), do: iso_string
+  def format_publication_date(_), do: ""
 end

--- a/lib/fuzzy_catalog_web/controllers/book_html/edit.html.heex
+++ b/lib/fuzzy_catalog_web/controllers/book_html/edit.html.heex
@@ -89,7 +89,13 @@
             <h3 class="text-lg font-semibold mb-3">Publishing Information</h3>
             <div class="space-y-4">
               <.input field={f[:publisher]} type="text" label="Publisher" />
-              <.input field={f[:publication_date]} type="date" label="Publication Date" />
+              <.input
+                field={f[:publication_date]}
+                type="text"
+                label="Publication Date"
+                placeholder="e.g., 2023, 2023-05, or 2023-05-15"
+                phx-debounce="300"
+              />
               <.input field={f[:pages]} type="number" label="Pages" />
               <.input field={f[:genre]} type="text" label="Genre" />
             </div>

--- a/lib/fuzzy_catalog_web/controllers/book_html/index.html.heex
+++ b/lib/fuzzy_catalog_web/controllers/book_html/index.html.heex
@@ -48,6 +48,40 @@
       </form>
 
       <div class="flex gap-2 items-center">
+        <!-- Sort Dropdown -->
+        <div class="dropdown dropdown-end">
+          <div tabindex="0" role="button" class="btn btn-outline btn-sm">
+            <.icon name="hero-arrows-up-down" class="h-4 w-4 mr-2" />
+            Sort: {current_sort_label(@meta)}
+            <.icon name="hero-chevron-down" class="h-3 w-3 ml-2" />
+          </div>
+          <ul
+            tabindex="0"
+            class="dropdown-content menu bg-base-100 rounded-box z-[1] w-60 p-2 shadow-lg border"
+          >
+            <%= for {label, field, direction} <- sort_options() do %>
+              <li>
+                <.link
+                  href={build_sort_url(@conn, @meta, field, direction)}
+                  class={[
+                    "flex items-center justify-between",
+                    if(current_sort(@meta) == {field, direction},
+                      do: "active font-semibold",
+                      else: ""
+                    )
+                  ]}
+                >
+                  <span>{label}</span>
+                  <%= if current_sort(@meta) == {field, direction} do %>
+                    <.icon name="hero-check" class="h-4 w-4" />
+                  <% end %>
+                </.link>
+              </li>
+            <% end %>
+          </ul>
+        </div>
+        
+<!-- View Toggle -->
         <.link
           href={toggle_view_url(@conn, @meta, current_view_mode(assigns))}
           class="btn btn-outline btn-sm"
@@ -226,42 +260,22 @@
   <% end %>
 
   <div class="mt-6 flex justify-center">
-    <%= if current_view_mode(assigns) == "grid" do %>
-      <Flop.Phoenix.pagination
-        meta={@meta}
-        path={~p"/books?view=grid"}
-        page_links={5}
-        page_list_attrs={[class: "join"]}
-        page_list_item_attrs={[]}
-        page_link_attrs={[class: "join-item btn btn-outline"]}
-        current_page_link_attrs={[class: "join-item btn btn-active"]}
-        disabled_link_attrs={[class: "join-item btn btn-disabled"]}
-      >
-        <:previous attrs={[class: "join-item btn btn-outline"]}>
-          <.icon name="hero-chevron-left" class="h-4 w-4" /> Previous
-        </:previous>
-        <:next attrs={[class: "join-item btn btn-outline"]}>
-          Next <.icon name="hero-chevron-right" class="h-4 w-4" />
-        </:next>
-      </Flop.Phoenix.pagination>
-    <% else %>
-      <Flop.Phoenix.pagination
-        meta={@meta}
-        path={~p"/books"}
-        page_links={5}
-        page_list_attrs={[class: "join"]}
-        page_list_item_attrs={[]}
-        page_link_attrs={[class: "join-item btn btn-outline"]}
-        current_page_link_attrs={[class: "join-item btn btn-active"]}
-        disabled_link_attrs={[class: "join-item btn btn-disabled"]}
-      >
-        <:previous attrs={[class: "join-item btn btn-outline"]}>
-          <.icon name="hero-chevron-left" class="h-4 w-4" /> Previous
-        </:previous>
-        <:next attrs={[class: "join-item btn btn-outline"]}>
-          Next <.icon name="hero-chevron-right" class="h-4 w-4" />
-        </:next>
-      </Flop.Phoenix.pagination>
-    <% end %>
+    <Flop.Phoenix.pagination
+      meta={@meta}
+      path={pagination_path(@conn)}
+      page_links={5}
+      page_list_attrs={[class: "join"]}
+      page_list_item_attrs={[]}
+      page_link_attrs={[class: "join-item btn btn-outline"]}
+      current_page_link_attrs={[class: "join-item btn btn-active"]}
+      disabled_link_attrs={[class: "join-item btn btn-disabled"]}
+    >
+      <:previous attrs={[class: "join-item btn btn-outline"]}>
+        <.icon name="hero-chevron-left" class="h-4 w-4" /> Previous
+      </:previous>
+      <:next attrs={[class: "join-item btn btn-outline"]}>
+        Next <.icon name="hero-chevron-right" class="h-4 w-4" />
+      </:next>
+    </Flop.Phoenix.pagination>
   </div>
 </Layouts.app>

--- a/lib/fuzzy_catalog_web/controllers/book_html/new.html.heex
+++ b/lib/fuzzy_catalog_web/controllers/book_html/new.html.heex
@@ -253,7 +253,7 @@
                     <p class="text-sm text-base-content/70">by {book.author}</p>
                     <%= if book.publication_date do %>
                       <p class="text-xs text-base-content/60">
-                        Published: {book.publication_date.year}
+                        Published: {format_publication_date(book.publication_date)}
                       </p>
                     <% end %>
                   </div>
@@ -274,7 +274,7 @@
             <p class="text-sm text-base-content/70">by {@lookup_results.author}</p>
             <%= if @lookup_results.publication_date do %>
               <p class="text-xs text-base-content/60">
-                Published: {@lookup_results.publication_date.year}
+                Published: {format_publication_date(@lookup_results.publication_date)}
               </p>
             <% end %>
             <.form :let={_f} for={%{}} action={~p"/books/new"} method="get" class="mt-2">

--- a/lib/fuzzy_catalog_web/controllers/book_html/show.html.heex
+++ b/lib/fuzzy_catalog_web/controllers/book_html/show.html.heex
@@ -106,7 +106,7 @@
           </:item>
           <:item :if={@book.publisher} title="Publisher">{@book.publisher}</:item>
           <:item :if={@book.publication_date} title="Publication Date">
-            {@book.publication_date}
+            {format_publication_date(@book.publication_date)}
           </:item>
           <:item :if={@book.pages} title="Pages">{@book.pages}</:item>
           <:item :if={@book.genre} title="Genre">{@book.genre}</:item>

--- a/priv/repo/migrations/20250817234224_convert_publication_date_to_iso_strings.exs
+++ b/priv/repo/migrations/20250817234224_convert_publication_date_to_iso_strings.exs
@@ -1,0 +1,102 @@
+defmodule FuzzyCatalog.Repo.Migrations.ConvertPublicationDateToIsoStrings do
+  use Ecto.Migration
+
+  import Ecto.Query
+  alias FuzzyCatalog.Repo
+
+  def up do
+    # Add new string column for ISO 8601 partial dates
+    alter table(:books) do
+      add :publication_date_new, :string
+    end
+
+    flush()
+
+    # Convert existing Date values to ISO 8601 strings
+    from(b in "books",
+      where: not is_nil(b.publication_date),
+      select: %{id: b.id, publication_date: b.publication_date}
+    )
+    |> Repo.all()
+    |> Enum.each(fn %{id: id, publication_date: date} ->
+      iso_string = convert_date_to_iso_string(date)
+
+      if iso_string do
+        from(b in "books", where: b.id == ^id)
+        |> Repo.update_all(set: [publication_date_new: iso_string])
+      end
+    end)
+
+    # Remove old date column and rename new column
+    alter table(:books) do
+      remove :publication_date
+    end
+
+    flush()
+
+    rename table(:books), :publication_date_new, to: :publication_date
+  end
+
+  def down do
+    # Add back the date column
+    alter table(:books) do
+      add :publication_date_old, :date
+    end
+
+    flush()
+
+    # Convert ISO strings back to Date format (only for full dates)
+    from(b in "books",
+      where: not is_nil(b.publication_date),
+      select: %{id: b.id, publication_date: b.publication_date}
+    )
+    |> Repo.all()
+    |> Enum.each(fn %{id: id, publication_date: iso_string} ->
+      date = convert_iso_string_to_date(iso_string)
+
+      if date do
+        from(b in "books", where: b.id == ^id)
+        |> Repo.update_all(set: [publication_date_old: date])
+      end
+    end)
+
+    # Remove string column and rename date column back
+    alter table(:books) do
+      remove :publication_date
+    end
+
+    flush()
+
+    rename table(:books), :publication_date_old, to: :publication_date
+  end
+
+  # Helper functions for data conversion
+  defp convert_date_to_iso_string(%Date{year: year, month: month, day: day}) do
+    # Convert Date struct to ISO 8601 string
+    year_str = String.pad_leading(to_string(year), 4, "0")
+    month_str = String.pad_leading(to_string(month), 2, "0")
+    day_str = String.pad_leading(to_string(day), 2, "0")
+    "#{year_str}-#{month_str}-#{day_str}"
+  end
+
+  defp convert_date_to_iso_string(_), do: nil
+
+  defp convert_iso_string_to_date(iso_string) when is_binary(iso_string) do
+    # Only convert full ISO dates back to Date structs
+    # Partial dates (year only, year-month) will be lost in the rollback
+    case String.split(iso_string, "-") do
+      [year, month, day]
+      when byte_size(year) == 4 and byte_size(month) == 2 and byte_size(day) == 2 ->
+        case Date.from_iso8601(iso_string) do
+          {:ok, date} -> date
+          {:error, _} -> nil
+        end
+
+      _ ->
+        # Skip partial dates - they can't be converted back to Date
+        nil
+    end
+  end
+
+  defp convert_iso_string_to_date(_), do: nil
+end


### PR DESCRIPTION
- Publication dates as actual date times prevented usage of publishYear from Audiobookshelf for example, as ISO 8601 strings they're now sortable and allow for just years etc.
- OpenLibrary provider was using legacy API from them, now it's using their current search API
- CI now setup to publish container images on tag instead